### PR TITLE
Mark myriad as an internal dependency

### DIFF
--- a/Pulumi.FSharp.Azure.fsproj
+++ b/Pulumi.FSharp.Azure.fsproj
@@ -44,7 +44,7 @@
         <PackageReference Include="Pulumi.Azure" Version="3.11.0" />
         <PackageReference Include="Pulumi.FSharp" Version="2.5.0" />
         <PackageReference Include="FSharp.Core" Version="4.7.2" />
-        <PackageReference Include="Myriad.Sdk" Version="0.2.8" />
+        <PackageReference Include="Myriad.Sdk" Version="0.2.8" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This just makes nuget ignore this dependency when packaging the project, so that consumers don't have to see that at all. This is similar to a `devDependency` in npm/yarn.